### PR TITLE
support more parameters in glance::backend::file

### DIFF
--- a/manifests/backend/file.pp
+++ b/manifests/backend/file.pp
@@ -5,12 +5,16 @@
 #  default_store == file.
 #  Optional. Default: /var/lib/glance/images/
 class glance::backend::file(
-  $filesystem_store_datadir = '/var/lib/glance/images/'
+  $filesystem_store_datadir = '/var/lib/glance/images/',
+  $scrubber_datadir = '/var/lib/glance/scrubber/',
+  $image_cache_dir = '/var/lib/glance/image-cache/',
 ) inherits glance::api {
 
   glance_api_config {
     'DEFAULT/default_store':            value => 'file';
     'DEFAULT/filesystem_store_datadir': value => $filesystem_store_datadir;
+    'DEFAULT/scrubber_datadir':         value => $scrubber_datadir;
+    'DEFAULT/image_cache_dir':          value => $image_cache_dir;
   }
 
   glance_cache_config {


### PR DESCRIPTION
including scrubber_datadir and image_cache_dir
